### PR TITLE
some testcases don't have a file

### DIFF
--- a/test-reports/summarize_test_results.py
+++ b/test-reports/summarize_test_results.py
@@ -195,16 +195,18 @@ def error_line_from_error_element(element):
 
 def testcase_id(testcase):
     """
-    Given a <testcase> element, return the a usuful display name
+    Given a <testcase> element, return the a useful display name
     for the test.
     """
     test_file = testcase.get("file")
 
-    # CMS tests don't seem to have the path starting from the top-level
-    # directory for some reason.  Perhaps because of where the pytest
-    # config is?  We might run into an issue when we collect common tests
-    # which might have the same problem.
-    if test_file.startswith("djangoapps"):
+    if not test_file:
+        test_file = "unknown"
+    elif test_file.startswith("djangoapps"):
+        # CMS tests don't seem to have the path starting from the top-level
+        # directory for some reason.  Perhaps because of where the pytest
+        # config is?  We might run into an issue when we collect common tests
+        # which might have the same problem.
         test_file = "cms/" + test_file
 
     return u"{filename}::{classname}::{name}".format(


### PR DESCRIPTION
For testcases that don't have a file, just outputs "unknown" for the
file name.  I'm not sure if the "CMS" case is always accurate, but I
left that untouched.